### PR TITLE
added functionality for .bandit config file

### DIFF
--- a/flake8_bandit.py
+++ b/flake8_bandit.py
@@ -40,7 +40,7 @@ class BanditTester(object):
         config = configparser.ConfigParser()
         try:
             config.read(ini_file)
-            profile = {k: v for k, v in config.items("bandit")}
+            profile = {k: v.replace("S", "B") for k, v in config.items("bandit")}
             if profile.get("skips"):
                 profile["exclude"] = profile.get("skips").split(",")
             if profile.get("tests"):

--- a/flake8_bandit.py
+++ b/flake8_bandit.py
@@ -2,13 +2,21 @@
 import ast
 
 import pycodestyle
+from flake8.options.config import ConfigFileFinder
+
 from bandit.core.config import BanditConfig
 from bandit.core.meta_ast import BanditMetaAst
 from bandit.core.metrics import Metrics
 from bandit.core.node_visitor import BanditNodeVisitor
 from bandit.core.test_set import BanditTestSet
 
-__version__ = "2.0.1"
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+
+
+__version__ = "2.1.0"
 
 
 class BanditTester(object):
@@ -28,10 +36,25 @@ class BanditTester(object):
         self.lines = lines
 
     def _check_source(self):
+        ini_file = ConfigFileFinder("bandit", None, None).local_config_files()
+        config = configparser.ConfigParser()
+        try:
+            config.read(ini_file)
+            profile = {k: v for k, v in config.items("bandit")}
+            if profile.get("skips"):
+                profile["exclude"] = profile.get("skips").split(",")
+            if profile.get("tests"):
+                profile["include"] = profile.get("tests").split(",")
+        except (configparser.Error, KeyError, TypeError) as e:
+            if str(e) != "No section: 'bandit'":
+                import sys
+                err = "Unable to parse config file: %s\n" % e
+                sys.stderr.write(err)
+            profile = {}
         bnv = BanditNodeVisitor(
             self.filename,
             BanditMetaAst(),
-            BanditTestSet(BanditConfig()),
+            BanditTestSet(BanditConfig(), profile=profile),
             False,
             [],
             Metrics(),

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 import sys
 from shutil import rmtree
 
-from setuptools import find_packages, setup, Command
+from setuptools import Command, setup
 
 
 def get_version(fname="flake8_bandit.py"):


### PR DESCRIPTION
This PR will add functionality for 'skips' and 'tests' in a .bandit config file. 

The plugin will look for the config file that is closest to the `pwd`. 

`.bandit` file example

```
[bandit]
skips = B101,B103
```

also works:

```
[bandit]
tests = B101
```

and if you mess up the prefix (since flake8 makes it an `S`) we will fix that for you too:

```
[bandit]
skips = S101
```