### PR TITLE
support all options in .bandit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@ Automated security testing built right into your workflow!
 
 You already use flake8 to lint all your code for errors, ensure docstrings are formatted correctly, sort your imports correctly, and much more... so why not ensure you are writing secure code while you're at it? If you already have flake8 installed all it takes is `pip install flake8-bandit`.
 
+## Configuration
+
+To include or exclude tests, use the standard `.bandit` configuration file. An example valid `.bandit` config file:
+
+```text
+[bandit]
+exclude = /frontend,/scripts,/tests,/venv
+tests: B101
+```
+
+In this case, we've specified to ignore a number of paths, and to only test for B101.
+
+**Note:**  flake8-bugbear uses bandit default prefix 'B' so this plugin replaces the 'B' with an 'S' for Security. For more information, see https://github.com/PyCQA/flake8-bugbear/issues/37
+
 ## How's it work?
 
 We use the [bandit](https://github.com/PyCQA/bandit) package from [PyCQA](http://meta.pycqa.org/en/latest/) for all the security testing.

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",
         "Topic :: Security",
         "Topic :: Software Development :: Libraries :: Python Modules",
@@ -121,4 +120,5 @@ setup(
     ],
     # $ setup.py publish support.
     cmdclass={"upload": UploadCommand},
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
- Updated flake8-bandit to support all `.bandit` config options including `targets` and `excludes`
- cache config parsing so it can be re-used as needed

Breaking change:
- python >= 3.6 required

I'm using a number of more modern python features, could of course rewrite with older methods but wanted to write the simple way first unless there are objections; for most projects I've worked on and other frequently used tools, it seems like python 3.6 is a reasonable minimum version (black, pydantic, etc).

Implements additional features as discussed in #3 