### PR TITLE
Make flake8-bandit work with latest bandit 1.7.3 version

### DIFF
--- a/flake8_bandit.py
+++ b/flake8_bandit.py
@@ -107,12 +107,13 @@ class BanditTester(object):
             return []
 
         bnv = BanditNodeVisitor(
-            self.filename,
-            BanditMetaAst(),
-            BanditTestSet(BanditConfig(), profile=config.profile),
-            False,
-            [],
-            Metrics(),
+            fname=self.filename,
+            fdata=None,
+            metaast=BanditMetaAst(),
+            testset=BanditTestSet(BanditConfig(), profile=config.profile),
+            debug=False,
+            nosec_lines=[],
+            metrics=Metrics(),
         )
         bnv.generic_visit(self.tree)
         return [

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ AUTHOR = "Tyler Wince"
 VERSION = get_version()
 
 # What packages are required for this module to be executed?
-REQUIRED = ["flake8", "bandit", "flake8-polyfill", "pycodestyle"]
+REQUIRED = ["flake8", "bandit>=1.7.3", "flake8-polyfill", "pycodestyle"]
 
 # What packages are optional?
 EXTRAS = {


### PR DESCRIPTION
Fixes #21

flake8-bandit 1.7.3 (https://github.com/PyCQA/bandit/pull/496)
introduced an `fdata` argument.