### PR TITLE
Make flake8-bandit work with latest bandit 1.7.3 too

### DIFF
--- a/flake8_bandit.py
+++ b/flake8_bandit.py
@@ -106,14 +106,26 @@ class BanditTester(object):
         ):
             return []
 
-        bnv = BanditNodeVisitor(
-            self.filename,
-            BanditMetaAst(),
-            BanditTestSet(BanditConfig(), profile=config.profile),
-            False,
-            [],
-            Metrics(),
-        )
+        try:
+            bnv = BanditNodeVisitor(
+                fname=self.filename,
+                fdata=None,
+                metaast=BanditMetaAst(),
+                testset=BanditTestSet(BanditConfig(), profile=config.profile),
+                debug=False,
+                nosec_lines=[],
+                metrics=Metrics(),
+            )
+        except TypeError:
+            # bandit < 1.7.3 (https://github.com/tylerwince/flake8-bandit/issues/21)
+            bnv = BanditNodeVisitor(
+                fname=self.filename,
+                metaast=BanditMetaAst(),
+                testset=BanditTestSet(BanditConfig(), profile=config.profile),
+                debug=False,
+                nosec_lines=[],
+                metrics=Metrics(),
+            )
         bnv.generic_visit(self.tree)
         return [
             {


### PR DESCRIPTION
Fixes: #21

flake8-bandit 1.7.3 (PyCQA/bandit#496) introduced an `fdata` argument and this just passes a `None` to make things work with the latest version of bandit.